### PR TITLE
feature: use in-memory map instead of cookies

### DIFF
--- a/scripts/release/check-release.js
+++ b/scripts/release/check-release.js
@@ -69,6 +69,7 @@ function checkPackageDependencyVersions(packageJsonFile) {
       if (
         isBrowserSdkPublicPackageName(dependencyName) &&
         !dependencyVersion.startsWith('portal:') &&
+        !dependencyVersion.startsWith('workspace:') &&
         dependencyVersion !== releaseVersion
       ) {
         throw new Error(


### PR DESCRIPTION
## Motivation

These are some customisations that we have to do to be able to use the library:

* Add transpiled js code to source-control, so that it can be required via npm.
* Use in-memory map instead of browser cookies.

# !!!!!! This PR should never be merged !!!!!!