### PR TITLE
feature: lern-fair adoptions to support our needs v4.46

### DIFF
--- a/packages/core/src/browser/cookie.ts
+++ b/packages/core/src/browser/cookie.ts
@@ -1,6 +1,6 @@
 import { display } from '../tools/display'
 import { ONE_MINUTE, ONE_SECOND } from '../tools/utils/timeUtils'
-import { findCommaSeparatedValue, generateUUID } from '../tools/utils/stringUtils'
+import { generateUUID } from '../tools/utils/stringUtils'
 
 export interface CookieOptions {
   secure?: boolean
@@ -8,22 +8,16 @@ export interface CookieOptions {
   domain?: string
 }
 
-export function setCookie(name: string, value: string, expireDelay: number, options?: CookieOptions) {
-  const date = new Date()
-  date.setTime(date.getTime() + expireDelay)
-  const expires = `expires=${date.toUTCString()}`
-  const sameSite = options && options.crossSite ? 'none' : 'strict'
-  const domain = options && options.domain ? `;domain=${options.domain}` : ''
-  const secure = options && options.secure ? ';secure' : ''
-  document.cookie = `${name}=${value};${expires};path=/;samesite=${sameSite}${domain}${secure}`
+export function setCookie(name: string, value: string, _expireDelay: number, _options?: CookieOptions) {
+  sessionStorage.setItem(name, value)
 }
 
 export function getCookie(name: string) {
-  return findCommaSeparatedValue(document.cookie, name)
+  return sessionStorage.getItem(name)
 }
 
-export function deleteCookie(name: string, options?: CookieOptions) {
-  setCookie(name, '', 0, options)
+export function deleteCookie(name: string, _options?: CookieOptions) {
+  sessionStorage.removeItem(name)
 }
 
 export function areCookiesAuthorized(options: CookieOptions): boolean {

--- a/packages/rum/package.json
+++ b/packages/rum/package.json
@@ -12,7 +12,7 @@
     "build:esm": "rm -rf esm && tsc -p tsconfig.esm.json"
   },
   "dependencies": {
-    "@datadog/browser-core": "4.46.0",
+    "@datadog/browser-core": "https://gitpkg.now.sh/corona-school/browser-sdk/packages/core?v4.46-lern-fair-packages",
     "@datadog/browser-rum-core": "4.46.0",
     "@datadog/browser-worker": "4.46.0"
   },


### PR DESCRIPTION
## Motivation

These are some customisations that we have to do to be able to use the library:

* Use in-memory map instead of browser cookies.

## Workflow

1) Do the change that you need.
2) Rebase the second branch on this one.
3) Execute `yarn build` and `yarn build:bundle` on the second branch.
4) Update the dependency in our user-app.
    ```
    npm install -u 'https://gitpkg.now.sh/corona-school/browser-sdk/packages/rum?lern-fair-packages'
    ```

# !!!!!! This PR should never be merged !!!!!!